### PR TITLE
Server: return structures with error and data

### DIFF
--- a/R/basedata.R
+++ b/R/basedata.R
@@ -108,7 +108,17 @@ basedata = R6Class("basedata",
       httr::stop_for_status(response)
 
       call_results <- httr::content(response, "parsed")
-      call_results
+      #  check the error field
+      e = call_results[['error']]
+      if (
+           (checkmate::test_scalar(e) && e != "")
+        || !checkmate::test_scalar(e) && length(e)
+        ) {
+        message ("ERROR is :", e, ":")
+        stop (e)
+      }
+
+      call_results[['result']]
     },
     load_data = function (params) {
       BiodiverseR:::load_data_(self, params = params)

--- a/R/basedata.R
+++ b/R/basedata.R
@@ -142,7 +142,4 @@ basedata = R6Class("basedata",
   )
 )
 
-is_null_or_na = function (x) {
-  is.null(x) || is.na(x)
-}
 

--- a/R/load_data.R
+++ b/R/load_data.R
@@ -3,36 +3,21 @@
 #'
 #'
 #' @param bd list
-#' @param r_data list
-#' @param raster_params list
-#' @param spreadsheet_params list
-#' @param delimited_text_params list
-#' @param shapefile_params list
+#' @param params list
 #'
 #' @export
 #' @examples
 #' if(interactive()) {
 #'   b = BiodiverseR::basedata$new(name = "trial")
+#'   success = b$load_data()
 #' }
 load_data_ = function (
     bd,
     params = list()
-    # r_data = NULL,
-    # raster_params = NULL,
-    # spreadsheet_params = NULL,
-    # delimited_text_params = NULL,
-    # shapefile_params = NULL
   ) {
   checkmate::assertR6(bd, c("basedata"))
   stopifnot(bd$server_status())
 
-  # params = list (
-  #   raster_params = raster_params,
-  #   spreadsheet_params = spreadsheet_params,
-  #   delimited_text_params = delimited_text_params,
-  #   shapefile_params = shapefile_params,
-  #   bd_params = r_data  # messy
-  # )
   #  a bit messy but allows for later expansion
   #  and still needs thought
   # params = as.list(match.call())
@@ -42,14 +27,6 @@ load_data_ = function (
     params[["bd_params"]] = params[["r_data"]]
     params[["r_data"]] = NULL
   }
-message(params)
-  #  server now instantiates a basedata on call to new()
-  # gp_count = bd$call_server("bd_get_group_count")
-  # message (gp_count)
-  # stopifnot (
-  #   checkmate::test_scalar(gp_count),
-  #   "basedata has been instantiated on server"
-  # )
 
   result = bd$call_server("bd_load_data", params)
 

--- a/inst/perl/lib/BiodiverseR.pm
+++ b/inst/perl/lib/BiodiverseR.pm
@@ -94,10 +94,12 @@ $log->debug("Called startup");
         my $result = eval {
             BiodiverseR::BaseData->init_basedata ($analysis_params);
             1;
-        } or die "Cannot initialise basedata";
+        };
+        my $e = $@;
+        return error_as_json ($c,  "Cannot initialise basedata, $e")
+            if $e;
 
-        #  should just return success or failure
-        return $c->render(json => $result);
+        return success_as_json ($c, $result);
     });
 
     $r->post ('/bd_load_data' => sub ($c) {
@@ -113,58 +115,78 @@ $log->debug("Called startup");
         };
         my $e = $@;
         $log->debug ($e) if $e;
-        croak "Cannot load data into basedata"
-          if !$result;
+        return error_as_json ($c, "Cannot load data into basedata, $e")
+          if $e;
         # my $bd = BiodiverseR::BaseData->get_basedata_ref;
         # say STDERR "LOADED, result is $result, group count is " . $bd->get_group_count;
         #  should just return success or failure
-        return $c->render(json => $result);
+        return success_as_json ($c, $result);
     });
 
     $r->post ('/bd_get_group_count' => sub ($c) {
         my $bd = BiodiverseR::BaseData->get_basedata_ref;
         my $result = $bd ? $bd->get_group_count : undef;
-        return $c->render(json => $result);
+        return success_as_json ($c, $result);
     });
 
     $r->post ('/bd_get_label_count' => sub ($c) {
         my $bd = BiodiverseR::BaseData->get_basedata_ref;
         my $result = $bd ? $bd->get_label_count : undef;
-        return $c->render(json => $result);
+        return success_as_json ($c, $result);
     });
 
     $r->post ('/bd_run_spatial_analysis' => sub ($c) {
         my $analysis_params = $c->req->json;
 
-        croak "analysis_params must be a hash structure"
-          if !is_hashref $analysis_params;
-
         $log->debug("parameters are:");
         $log->debug(np ($analysis_params));
         $log->debug("About to call run_spatial_analysis");
 
+        return error_as_json($c,
+            ('analysis_params must be a hash structure, got '
+            . reftype($analysis_params)))
+          if !is_hashref ($analysis_params);
+
         my $result = eval {
             BiodiverseR::BaseData->run_spatial_analysis ($analysis_params);
         };
-        croak "Cannot run spatial analysis, $@"
-            if $@;
-        # my $bd = BiodiverseR::BaseData->get_basedata_ref;
-        # say STDERR "LOADED, result is $result, group count is " . $bd->get_group_count;
-        #  should just return success or failure
-        return $c->render(json => $result);
+        my $e = $@;
+        return error_as_json($c, "Cannot run spatial analysis\n$e")
+            if $e;
+
+        return success_as_json($c, $result);
     });
 
     $r->post ('/bd_save_to_bds' => sub ($c) {
         my $args = $c->req->json;
         my $filename = $args->{filename};
-        my $bd = BiodiverseR::BaseData->get_basedata_ref;
-        return $c->render(json => undef)
-          if !$bd || !defined $filename;
-        my $result = $bd->save(filename => $filename);
-        return $c->render(json => defined $result);
+        my $result = eval {
+            my $bd = BiodiverseR::BaseData->get_basedata_ref;
+            return $c->render(json => undef)
+                if !$bd || !defined $filename;
+            $bd->save(filename => $filename);
+        };
+        my $e = $@;
+        return $c->render(json => {error => $e, result => defined $result});
     });
 
+    sub success_as_json ($c, $result) {
+        return $c->render(
+            json => {
+                error  => undef,
+                result => $result,
+            }
+        );
+    }
 
+    sub error_as_json ($c, $error) {
+        return $c->render(
+            json => {
+                error  => $error,
+                result => undef
+            }
+        );
+    }
 
 }
 

--- a/inst/perl/lib/BiodiverseR.pm
+++ b/inst/perl/lib/BiodiverseR.pm
@@ -63,10 +63,17 @@ $log->debug("Called startup");
   # Normal route to controller
   $r->get('/')->to('Example#welcome');
 
-  $r->get('/calculations_metadata' => sub ($c) {
-      my $metadata = BiodiverseR::IndicesMetadata->get_indices_metadata();
-      return $c->render(json => $metadata);
-  });
+    $r->get('/calculations_metadata' => sub ($c) {
+        my $metadata;
+        my $success = eval {
+            $metadata = BiodiverseR::IndicesMetadata->get_indices_metadata();
+            1;
+        };
+        my $e = $@;
+        return error_as_json($c, $e)
+          if $e;
+        return success_as_json($c, $metadata);
+    });
 
     #  pass some data, get a result.  Or the broken pieces.
     $r->post ('/analysis_spatial_oneshot' => sub ($c) {

--- a/inst/perl/t/01-metadata.t
+++ b/inst/perl/t/01-metadata.t
@@ -9,10 +9,10 @@ my $t = Test::Mojo->new('BiodiverseR');
 $t->get_ok('/calculations_metadata')->status_is(200);
 
 #  pretty basic
-$t->json_has ('/calc_phylo_rpe2/description');
-$t->json_has ('/calc_endemism_whole/indices/ENDW_CWE');
-$t->json_has ('/calc_phylo_rpd2/required_args');
-$t->json_has ('/calc_phylo_rpe2/indices/PHYLO_RPE_DIFF2/description');
+$t->json_has ('/result/calc_phylo_rpe2/description');
+$t->json_has ('/result/calc_endemism_whole/indices/ENDW_CWE');
+$t->json_has ('/result/calc_phylo_rpd2/required_args');
+$t->json_has ('/result/calc_phylo_rpe2/indices/PHYLO_RPE_DIFF2/description');
 
 # use Data::Printer;
 # p $t->tx->res->json;

--- a/inst/perl/t/02-singleton.t
+++ b/inst/perl/t/02-singleton.t
@@ -15,16 +15,19 @@ my $t = Test::Mojo->new('BiodiverseR');
 $t->get_ok('/')->status_is(200)->content_like(qr/Mojolicious/i);
 
 my $exp = {
-    SPATIAL_RESULTS => [
-        [qw /ELEMENT Axis_0 Axis_1 ENDC_CWE ENDC_RICHNESS ENDC_SINGLE ENDC_WE PD PD_P PD_P_per_taxon PD_per_taxon REDUNDANCY_ALL REDUNDANCY_SET1/],
-        ['250:250', '250', '250', '0.25', 3, '0.75', '0.75', 4, 1, '0.333333333333333', '1.33333333333333', '0.99992743983553',  '0.99992743983553'],
-        ['250:750', '250', '750', '0.25', 3, '0.75', '0.75', 4, 1, '0.333333333333333', '1.33333333333333', '0.999910222647833', '0.999910222647833'],
-        ['750:250', '750', '250', '0.25', 3, '0.75', '0.75', 4, 1, '0.333333333333333', '1.33333333333333', '0.999909793426948', '0.999909793426948'],
-        ['750:750', '750', '750', '0.25', 3, '0.75', '0.75', 4, 1, '0.333333333333333', '1.33333333333333', '0.999885974914481', '0.999885974914481'],
-    ]
+    result => {
+        SPATIAL_RESULTS => [
+            [ qw/ELEMENT Axis_0 Axis_1 ENDC_CWE ENDC_RICHNESS ENDC_SINGLE ENDC_WE PD PD_P PD_P_per_taxon PD_per_taxon REDUNDANCY_ALL REDUNDANCY_SET1/ ],
+            [ '250:250', '250', '250', '0.25', 3, '0.75', '0.75', 4, 1, '0.333333333333333', '1.33333333333333', '0.99992743983553', '0.99992743983553' ],
+            [ '250:750', '250', '750', '0.25', 3, '0.75', '0.75', 4, 1, '0.333333333333333', '1.33333333333333', '0.999910222647833', '0.999910222647833' ],
+            [ '750:250', '750', '250', '0.25', 3, '0.75', '0.75', 4, 1, '0.333333333333333', '1.33333333333333', '0.999909793426948', '0.999909793426948' ],
+            [ '750:750', '750', '750', '0.25', 3, '0.75', '0.75', 4, 1, '0.333333333333333', '1.33333333333333', '0.999885974914481', '0.999885974914481' ],
+        ]
+    },
+    error  => undef,
 };
 
-#  plenty repetition below - could do with a refactor
+
 my $json_tree = '{"edge":[4,5,5,4,5,1,2,3],"edge.length":["NaN",1,1,2],"Nnode":2,"tip.label":["r1","r2","r3"]}';
 my $tree = JSON::MaybeXS::decode_json ($json_tree);
 # p $tree;
@@ -85,18 +88,18 @@ foreach my $file_type (@file_arg_keys) {
     my $t_msg_suffix = "default config, $file_type";
     $t->post_ok('/init_basedata' => json => $bd_params)
         ->status_is(200, "status init, $t_msg_suffix")
-        ->json_is('' => 1, "json results, $t_msg_suffix");
+        ->json_is('' => {result => 1, error => undef}, "json results, $t_msg_suffix");
 
     $t->post_ok('/bd_load_data' => json => $data_params)
         ->status_is(200, "status load data, $t_msg_suffix")
-        ->json_is('' => 1, "json results, $t_msg_suffix");
+        ->json_is('' => {result => 1, error => undef}, "json results, $t_msg_suffix");
 
     $t->post_ok('/bd_get_group_count')
         ->status_is(200, "status gp count, $t_msg_suffix")
-        ->json_is('' => 4, "group count, $t_msg_suffix");
+        ->json_is('' => {result => 4, error => undef}, "group count, $t_msg_suffix");
     $t->post_ok('/bd_get_label_count')
         ->status_is(200, "status lb count, $t_msg_suffix")
-        ->json_is('' => 3, "label count, $t_msg_suffix");
+        ->json_is('' => {result => 3, error => undef}, "label count, $t_msg_suffix");
 
 
     $t->post_ok('/bd_run_spatial_analysis' => json => \%analysis_args)
@@ -111,7 +114,7 @@ foreach my $file_type (@file_arg_keys) {
         my $filename = Mojo::File->new($dir, "$file_type.bds");
         $t->post_ok('/bd_save_to_bds' => json => {filename => $filename})
             ->status_is(200, "status save basedata, $t_msg_suffix")
-            ->json_is('' => 1, "json results, $t_msg_suffix");
+            ->json_is('' => {result => 1, error => ''}, "json results, $t_msg_suffix");
         ok -e $filename, "$filename exists";
         my $bd = Biodiverse::BaseData->new(file => $filename);
         is $bd->get_group_count, 4, "saved basedata has expected group count";


### PR DESCRIPTION
This simplifies debugging because now the errors are available on the client instead of buried in a log file.

Fixes #47 